### PR TITLE
Add unit and e2e tests with coverage enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest",
+    "test": "jest --coverage",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
@@ -95,6 +95,14 @@
     "testEnvironment": "node",
     "moduleNameMapper": {
       "^src/(.*)$": "<rootDir>/$1"
+    },
+    "coverageThreshold": {
+      "global": {
+        "branches": 70,
+        "functions": 70,
+        "lines": 70,
+        "statements": 70
+      }
     }
   }
 }

--- a/src/orders/orders.service.spec.ts
+++ b/src/orders/orders.service.spec.ts
@@ -1,0 +1,81 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken, getConnectionToken } from '@nestjs/mongoose';
+import { OrdersService } from './orders.service';
+import { Order } from '../schemas/order.schema';
+import { Product } from '../schemas/product.schema';
+import { Address } from '../schemas/address.schema';
+import { User } from '../schemas/user.schema';
+import { CartService } from '../cart/cart.service';
+import { PaymentsService } from '../payments/payments.service';
+import { Types } from 'mongoose';
+import { NotFoundException } from '@nestjs/common';
+
+
+describe('OrdersService', () => {
+  let service: OrdersService;
+  let orderModel: any;
+  let productModel: { findById: jest.Mock };
+
+  beforeEach(async () => {
+    const mockOrderModel = jest.fn().mockImplementation((dto) => ({
+      ...dto,
+      save: jest.fn().mockResolvedValue({ _id: 'orderId', ...dto }),
+    }));
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrdersService,
+        { provide: getModelToken(Order.name), useValue: mockOrderModel },
+        { provide: getModelToken(Product.name), useValue: { findById: jest.fn() } },
+        { provide: getModelToken(Address.name), useValue: {} },
+        { provide: getModelToken(User.name), useValue: {} },
+        { provide: CartService, useValue: {} },
+        { provide: PaymentsService, useValue: {} },
+        { provide: getConnectionToken(), useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<OrdersService>(OrdersService);
+    orderModel = module.get(getModelToken(Order.name));
+    productModel = module.get(getModelToken(Product.name));
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('create', () => {
+    it('should create an order with valid products', async () => {
+      productModel.findById.mockReturnValue({
+        exec: jest.fn().mockResolvedValue({
+          _id: 'p1',
+          name: 'Prod',
+          price: 5,
+          images: ['img'],
+        }),
+      });
+
+      const dto: any = {
+        items: [{ productId: 'p1', quantity: 2 }],
+        shippingAddress: {
+          street: 'a',
+          city: 'b',
+          state: 'c',
+          zipCode: 'd',
+          country: 'e',
+        },
+      };
+
+      const result = await service.create(dto, new Types.ObjectId());
+      expect(result.totalAmount).toBe(10);
+      expect(orderModel).toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when product missing', async () => {
+      productModel.findById.mockReturnValue({ exec: jest.fn().mockResolvedValue(null) });
+      const dto: any = {
+        items: [{ productId: 'p1', quantity: 1 }],
+        shippingAddress: { street: 'a', city: 'b', state: 'c', zipCode: 'd', country: 'e' },
+      };
+      await expect(service.create(dto, new Types.ObjectId())).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/src/products/products.service.spec.ts
+++ b/src/products/products.service.spec.ts
@@ -1,0 +1,80 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { ProductsService } from './products.service';
+import { Product, ProductDocument } from '../schemas/product.schema';
+import { Category, CategoryDocument } from '../schemas/category.schema';
+import { Model, Types } from 'mongoose';
+import { BadRequestException } from '@nestjs/common';
+
+
+describe('ProductsService', () => {
+  let service: ProductsService;
+  let productModel: any;
+  let categoryModel: { countDocuments: jest.Mock };
+
+  beforeEach(async () => {
+    const mockProductModel = jest.fn().mockImplementation(() => ({
+      save: jest.fn().mockResolvedValue({ name: 'Saved' }),
+    }));
+    mockProductModel.find = jest.fn();
+    mockProductModel.findById = jest.fn();
+    mockProductModel.findByIdAndUpdate = jest.fn();
+    mockProductModel.findByIdAndDelete = jest.fn();
+
+    const mockCategoryModel = { countDocuments: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProductsService,
+        { provide: getModelToken(Product.name), useValue: mockProductModel },
+        { provide: getModelToken(Category.name), useValue: mockCategoryModel },
+      ],
+    }).compile();
+
+    service = module.get<ProductsService>(ProductsService);
+    productModel = module.get(getModelToken(Product.name));
+    categoryModel = module.get(getModelToken(Category.name));
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('create', () => {
+    it('should create a product when categories exist', async () => {
+      categoryModel.countDocuments.mockResolvedValue(1);
+      const dto: any = { name: 'P', price: 10, categoryIds: ['1'] };
+      const result = await service.create(dto);
+      expect(result).toEqual({ name: 'Saved' });
+      expect(categoryModel.countDocuments).toHaveBeenCalledWith({
+        _id: { $in: dto.categoryIds },
+      });
+    });
+
+    it('should throw BadRequestException when category IDs are invalid', async () => {
+      categoryModel.countDocuments.mockResolvedValue(0);
+      const dto: any = { name: 'P', price: 10, categoryIds: ['1'] };
+      await expect(service.create(dto)).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all products', async () => {
+      const docs = [{ name: 'A' }];
+      productModel.find.mockReturnValue({ exec: jest.fn().mockResolvedValue(docs) });
+      const result = await service.findAll();
+      expect(result).toEqual(docs);
+      expect(productModel.find).toHaveBeenCalledWith({});
+    });
+
+    it('should filter by category id', async () => {
+      const docs = [{ name: 'A' }];
+      productModel.find.mockReturnValue({ exec: jest.fn().mockResolvedValue(docs) });
+      const id = new Types.ObjectId().toString();
+      await service.findAll(id);
+      expect(productModel.find).toHaveBeenCalledWith({ categoryIds: new Types.ObjectId(id) });
+    });
+
+    it('should throw for invalid category id', async () => {
+      await expect(service.findAll('bad-id')).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/test/orders.e2e-spec.ts
+++ b/test/orders.e2e-spec.ts
@@ -1,0 +1,55 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, CanActivate, ExecutionContext } from '@nestjs/common';
+import request from 'supertest';
+import { OrdersController } from '../src/orders/orders.controller';
+import { OrdersService } from '../src/orders/orders.service';
+import { AuthGuard } from '@nestjs/passport';
+import { RolesGuard } from '../src/common/guards/roles.guard';
+
+class MockAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext) {
+    const req = context.switchToHttp().getRequest();
+    req.user = { _id: 'user1', role: 'User' };
+    return true;
+  }
+}
+class MockRolesGuard implements CanActivate {
+  canActivate() {
+    return true;
+  }
+}
+
+describe('Orders (e2e)', () => {
+  let app: INestApplication;
+  const mockOrdersService = { create: jest.fn().mockResolvedValue({ id: 'order1', totalAmount: 10 }) };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [OrdersController],
+      providers: [{ provide: OrdersService, useValue: mockOrdersService }],
+    })
+      .overrideGuard(AuthGuard('jwt'))
+      .useClass(MockAuthGuard)
+      .overrideGuard(RolesGuard)
+      .useClass(MockRolesGuard)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should place an order', () => {
+    return request(app.getHttpServer())
+      .post('/orders')
+      .send({
+        items: [{ productId: 'p1', quantity: 2 }],
+        shippingAddress: { street: 'a', city: 'b', state: 'c', zipCode: 'd', country: 'e' },
+      })
+      .expect(201)
+      .expect({ id: 'order1', totalAmount: 10 });
+  });
+});

--- a/test/payments.e2e-spec.ts
+++ b/test/payments.e2e-spec.ts
@@ -1,0 +1,35 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { PaymentsController } from '../src/payments/payments.controller';
+import { PaymentsService } from '../src/payments/payments.service';
+
+describe('Payments (e2e)', () => {
+  let app: INestApplication;
+  const mockPaymentsService = { handleWebhook: jest.fn().mockResolvedValue(undefined) };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [PaymentsController],
+      providers: [{ provide: PaymentsService, useValue: mockPaymentsService }],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should process webhook', () => {
+    return request(app.getHttpServer())
+      .post('/payments/webhook')
+      .set('x-razorpay-signature', 'sig')
+      .send('{"event":"test"}')
+      .expect(200)
+      .then(() => {
+        expect(mockPaymentsService.handleWebhook).toHaveBeenCalled();
+      });
+  });
+});

--- a/test/registration.e2e-spec.ts
+++ b/test/registration.e2e-spec.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { AuthController } from '../src/auth/auth.controller';
+import { AuthService } from '../src/auth/auth.service';
+
+describe('Registration (e2e)', () => {
+  let app: INestApplication;
+  const mockAuthService = { register: jest.fn().mockResolvedValue({ id: '1', email: 'test@example.com' }) };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [{ provide: AuthService, useValue: mockAuthService }],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should register a user', () => {
+    return request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ email: 'test@example.com', password: 'pass' })
+      .expect(201)
+      .expect({ id: '1', email: 'test@example.com' });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for OrdersService and ProductsService
- add e2e tests for registration, orders, and payments
- run tests with coverage and enforce thresholds via CI

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run test:e2e` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d91c196148332845394f1f67b3642